### PR TITLE
Scaffolding for coadd tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Run tests
         shell: bash -l {0}
         run: |
-          pytest -v descwl_coadd_task/tests/ --cov= --cov-report=xml --cov-report=term-missing
+          pytest -v --cov descwl_coadd_task/ --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v4.6.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.1.1
     hooks:
       - id: flake8
   - repo: https://github.com/psf/black
-    rev: 23.12.1
+    rev: 24.8.0
     hooks:
       - id: black
         language_version: python3.11

--- a/descwl_coadd_task/_coadd_task.py
+++ b/descwl_coadd_task/_coadd_task.py
@@ -17,6 +17,7 @@ from descwl_coadd import (
     make_coadd,
     make_stacker,
 )
+from descwl_coadd.defaults import BOUNDARY_BIT_NAME
 from lsst.cell_coadds import (
     CellIdentifiers,
     CoaddUnits,
@@ -370,7 +371,7 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
 
         # gc = self._construct_grid_container(skyInfo, statsCtrl)
         # coadd_inputs_gc = GridContainer(gc.shape)
-        edge = afwImage.Mask.getPlaneBitMask(["EDGE", "NO_DATA"])
+        edge = afwImage.Mask.getPlaneBitMask([BOUNDARY_BIT_NAME, "NO_DATA"])
 
         cells: list[SingleCellCoadd] = []
         for cellInfo in skyInfo.patchInfo:
@@ -395,7 +396,7 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
                 # Coadd the warp onto the cells it completely overlaps.
                 if (mi.getMask().array & edge).any():
                     self.log.debug(
-                        "Skipping %s in cell %s because it has an EDGE",
+                        "Skipping %s in cell %s because it has an edge",
                         warpRef.dataId,
                         cellInfo.index,
                     )

--- a/descwl_coadd_task/_coadd_task.py
+++ b/descwl_coadd_task/_coadd_task.py
@@ -370,7 +370,7 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
 
         # gc = self._construct_grid_container(skyInfo, statsCtrl)
         # coadd_inputs_gc = GridContainer(gc.shape)
-        edge = afwImage.Mask.getPlaneBitMask("EDGE")
+        edge = afwImage.Mask.getPlaneBitMask(["EDGE", "NO_DATA"])
 
         cells: list[SingleCellCoadd] = []
         for cellInfo in skyInfo.patchInfo:

--- a/descwl_coadd_task/_coadd_task.py
+++ b/descwl_coadd_task/_coadd_task.py
@@ -492,7 +492,6 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
             )
 
             cells.append(scc)
-            break
 
         grid = self._construct_grid(skyInfo)
         mcc = MultipleCellCoadd(

--- a/descwl_coadd_task/_coadd_task.py
+++ b/descwl_coadd_task/_coadd_task.py
@@ -219,7 +219,7 @@ class AssembleShearCoaddTask(PipelineTask):
             skyMap, tractId=outputDataId["tract"], patchId=outputDataId["patch"]
         )
 
-        self.common = CommonComponents(
+        common = CommonComponents(
             units=CoaddUnits.nJy,
             wcs=inputData["skyInfo"].patchInfo.wcs,
             band=outputDataId.get("band", None),
@@ -231,11 +231,12 @@ class AssembleShearCoaddTask(PipelineTask):
             noise_warps=inputData["noise0_warps"],
             mfrac_warps=inputData["mfrac_warps"],
             skyInfo=inputData["skyInfo"],
+            common=common,
         )
         butlerQC.put(returnStruct, outputRefs)
         return returnStruct
 
-    def run(self, *, input_warps, mfrac_warps, noise_warps, skyInfo):
+    def run(self, *, input_warps, mfrac_warps, noise_warps, skyInfo, common, **kwargs):
         raise NotImplementedError("This method is not yet implemented.")
 
     @staticmethod
@@ -344,7 +345,7 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
     ConfigClass = AssembleShearCoaddSlowConfig
     _DefaultName = "assembleShearCoaddSlow"
 
-    def run(self, *, input_warps, noise_warps, mfrac_warps, skyInfo):
+    def run(self, *, input_warps, noise_warps, mfrac_warps, skyInfo, common, **kwargs):
         """Coadd a set of warped images, along with noise and masked fractions.
 
         Parameters
@@ -357,6 +358,8 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
             List of data references of masked fraction images.
         skyInfo : `~lsst.pipe.base.Struct`
             A Struct object
+        common : `~lsst.cell_coadds.CommonComponents`
+            A container for common components such as units, wcs, and band etc.
 
         Returns
         -------
@@ -473,10 +476,10 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
 
             identifiers = CellIdentifiers(
                 cell=cellInfo.index,
-                skymap=self.common.identifiers.skymap,
-                tract=self.common.identifiers.tract,
-                patch=self.common.identifiers.patch,
-                band=self.common.identifiers.band,
+                skymap=common.identifiers.skymap,
+                tract=common.identifiers.tract,
+                patch=common.identifiers.patch,
+                band=common.identifiers.band,
             )
 
             scc = SingleCellCoadd(
@@ -484,7 +487,7 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
                 psf=coadd_data["coadd_psf_exp"].image,
                 inner_bbox=cellInfo.inner_bbox,
                 inputs=None,
-                common=self.common,
+                common=common,
                 identifiers=identifiers,
             )
 
@@ -497,7 +500,7 @@ class AssembleShearCoaddSlowTask(AssembleShearCoaddTask):
             grid=grid,
             outer_cell_size=cellInfo.outer_bbox.getDimensions(),
             inner_bbox=None,
-            common=self.common,
+            common=common,
             psf_image_size=cells[0].psf_image.getDimensions(),
         )
 

--- a/descwl_coadd_task/_warp_task.py
+++ b/descwl_coadd_task/_warp_task.py
@@ -380,6 +380,7 @@ class MakeShearWarpTask(PipelineTask):
         # The warped PSF is not suitable for WL shear measurement.
         # We nevertheless attach it here and recompute the PSF for shear
         # during coaddition.
+        self.log.info("total_good_pixels = %d", total_good_pixels)
         inputRecorder.finish(final_warp, total_good_pixels)
         final_psf = CoaddPsf(inputRecorder.coaddInputs.ccds, coadd_wcs)
         final_warp.setPsf(final_psf)

--- a/descwl_coadd_task/tests/test_coadds.py
+++ b/descwl_coadd_task/tests/test_coadds.py
@@ -4,10 +4,8 @@ import unittest
 from typing import TYPE_CHECKING, Iterable
 
 import lsst.afw.cameraGeom.testUtils
-import lsst.afw.image as afw_image
 import lsst.utils.tests
 import numpy as np
-from lsst.afw.detection import GaussianPsf
 from lsst.cell_coadds import (
     CoaddUnits,
     CommonComponents,
@@ -26,7 +24,6 @@ from descwl_coadd_task.utils_for_tests import (
     build_skyMap,
     construct_geometry,
     fill_exposure,
-    generate_data_id,
     generate_photoCalib,
 )
 
@@ -103,170 +100,6 @@ class AssembleCoaddTestCase(lsst.utils.tests.TestCase):
         for _, exposureRefs in self.dataRefsDict.items():
             for exposureRef in exposureRefs:
                 exposureRef.get().mask.clearAllMaskPlanes()
-
-    @classmethod
-    def _constdfgdfgruct_geometry(cls, visit_id: int):
-        """Generate the necessary dataRefs to run the MakeWarpTask.
-
-        This is primarily setting up the geometry of the input exposures,
-        along with some metadata.
-        """
-
-        match visit_id:
-
-            case 204706:
-                crpixList = [
-                    lsst.geom.Point2D(1990.63, 2018.46),
-                    lsst.geom.Point2D(2186.46, 2044.82),
-                ]
-                crvalList = [
-                    lsst.geom.SpherePoint(
-                        57.14 * lsst.geom.degrees, -36.51 * lsst.geom.degrees
-                    ),
-                    lsst.geom.SpherePoint(
-                        57.39 * lsst.geom.degrees, -36.63 * lsst.geom.degrees
-                    ),
-                ]
-                cdMatrix = lsst.afw.geom.makeCdMatrix(
-                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
-                    orientation=122.9 * lsst.geom.degrees,
-                )
-                detectorNums = [158, 161]
-
-            case 204708:
-                crpixList = [
-                    lsst.geom.Point2D(2111.48, 1816.14),
-                    lsst.geom.Point2D(1971.88, 1899.54),
-                    lsst.geom.Point2D(1863.09, 1939.27),
-                ]
-                crvalList = [
-                    lsst.geom.SpherePoint(
-                        57.28 * lsst.geom.degrees, -36.66 * lsst.geom.degrees
-                    ),
-                    lsst.geom.SpherePoint(
-                        57.19 * lsst.geom.degrees, -36.35 * lsst.geom.degrees
-                    ),
-                    lsst.geom.SpherePoint(
-                        57.43 * lsst.geom.degrees, -36.48 * lsst.geom.degrees
-                    ),
-                ]
-                cdMatrix = lsst.afw.geom.makeCdMatrix(
-                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
-                    orientation=121.52 * lsst.geom.degrees,
-                )
-                detectorNums = [32, 36, 39]
-
-            case 174534:
-                crpixList = [
-                    lsst.geom.Point2D(1929.4499812439476, 2147.1179041443015),
-                    lsst.geom.Point2D(2012.9460541750886, 2073.7299107964782),
-                    lsst.geom.Point2D(2259.5002281485358, 2105.9109483821226),
-                ]
-                crvalList = [
-                    lsst.geom.SpherePoint(
-                        55.94990987622795 * lsst.geom.degrees,
-                        -36.18810977436167 * lsst.geom.degrees,
-                    ),
-                    lsst.geom.SpherePoint(
-                        56.02684930702103 * lsst.geom.degrees,
-                        -35.96612774405456 * lsst.geom.degrees,
-                    ),
-                    lsst.geom.SpherePoint(
-                        55.733500259251784 * lsst.geom.degrees,
-                        -35.89282833381862 * lsst.geom.degrees,
-                    ),
-                ]
-                cdMatrix = lsst.afw.geom.makeCdMatrix(
-                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
-                    orientation=16.69 * lsst.geom.degrees,
-                )
-                detectorNums = [12, 15, 16]
-
-            case 397330:
-
-                crpixList = [
-                    lsst.geom.Point2D(2038.0123728146252, 1886.2009723798765),
-                    lsst.geom.Point2D(2165.4630755512139, 1991.9349231803017),
-                ]
-                crvalList = [
-                    lsst.geom.SpherePoint(
-                        56.05982507585136 * lsst.geom.degrees,
-                        -36.04171236047266 * lsst.geom.degrees,
-                    ),
-                    lsst.geom.SpherePoint(
-                        56.01232760335289 * lsst.geom.degrees,
-                        -35.80314141320685 * lsst.geom.degrees,
-                    ),
-                ]
-                cdMatrix = lsst.afw.geom.makeCdMatrix(
-                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
-                    orientation=352.56 * lsst.geom.degrees,
-                )
-
-                detectorNums = [78, 117]
-
-            case 1248:
-                crpixList = [
-                    lsst.geom.Point2D(2047.84, 1909.10),
-                    lsst.geom.Point2D(2110.05, 1982.96),
-                    lsst.geom.Point2D(2104.22, 1780.364),
-                ]
-                crvalList = [
-                    lsst.geom.SpherePoint(
-                        56.16 * lsst.geom.degrees, -36.84 * lsst.geom.degrees
-                    ),
-                    lsst.geom.SpherePoint(
-                        56.33 * lsst.geom.degrees, -36.64 * lsst.geom.degrees
-                    ),
-                    lsst.geom.SpherePoint(
-                        56.40 * lsst.geom.degrees, -36.96 * lsst.geom.degrees
-                    ),
-                ]
-                cdMatrix = lsst.afw.geom.makeCdMatrix(
-                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
-                    orientation=123.5 * lsst.geom.degrees,
-                )
-
-                detectorNums = [107, 114, 146]
-
-            case _:
-                raise ValueError(
-                    f"{visit_id} is not supported. It must be one of "
-                    "[1248, 204706, 397330]"
-                )
-
-        dataRefs = []
-
-        for detId, detectorNum in enumerate(detectorNums):
-            wcs = lsst.afw.geom.makeSkyWcs(crpixList[detId], crvalList[detId], cdMatrix)
-            exposure = afw_image.ExposureF(cls.nx, cls.ny)
-
-            # Set the PhotoCalib, Wcs and detector objects of this exposure.
-            exposure.setPhotoCalib(cls.photoCalib)
-            exposure.setPsf(GaussianPsf(25, 25, 2.5))
-            exposure.setFilter(
-                afw_image.FilterLabel(physical="fakeFilter", band="fake")
-            )
-            exposure.setWcs(wcs)
-
-            detectorName = f"detector {detectorNum}"
-            detector = lsst.afw.cameraGeom.testUtils.DetectorWrapper(
-                name=detectorName,
-                id=detectorNum,
-            ).detector
-            exposure.setDetector(detector)
-
-            dataId_dict = {
-                "detector_id": detectorNum,
-                "visit_id": visit_id,
-                "band": "fake",
-            }
-            dataId = generate_data_id(**dataId_dict)
-            dataRef = InMemoryDatasetHandle(exposure, dataId=dataId)
-
-            dataRefs.append(dataRef)
-
-        return dataRefs
 
     def checkSortOrder(self, inputs: Iterable[ObservationIdentifiers]) -> None:
         """Check that the inputs are sorted.

--- a/descwl_coadd_task/tests/test_coadds.py
+++ b/descwl_coadd_task/tests/test_coadds.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import unittest
+from typing import TYPE_CHECKING, Iterable
+
+import lsst.afw.cameraGeom.testUtils
+import lsst.afw.image as afw_image
+import lsst.utils.tests
+import numpy as np
+from lsst.afw.detection import GaussianPsf
+from lsst.cell_coadds import (
+    CoaddUnits,
+    CommonComponents,
+    MultipleCellCoadd,
+    PatchIdentifiers,
+)
+from lsst.pipe.base import InMemoryDatasetHandle
+from lsst.pipe.tasks.coaddBase import makeSkyInfo
+
+from descwl_coadd_task import (
+    AssembleShearCoaddSlowTask,
+    MakeShearWarpConfig,
+    MakeShearWarpTask,
+)
+from descwl_coadd_task.utils_for_tests import (
+    build_skyMap,
+    construct_geometry,
+    fill_exposure,
+    generate_data_id,
+    generate_photoCalib,
+)
+
+if TYPE_CHECKING:
+    from lsst.cell_coadds import ObservationIdentifiers
+
+
+PIXEL_SCALE = 0.2
+"""Pixel scale in arcseconds."""
+
+
+class MockAssembleShearCoaddSlowTask(AssembleShearCoaddSlowTask):
+    """Mock a PipelineTask bypassing the middleware for testing."""
+
+
+class AssembleCoaddTestCase(lsst.utils.tests.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.skyMap = build_skyMap()
+        cls.photoCalib = generate_photoCalib()
+        cls.skyInfo = makeSkyInfo(cls.skyMap, tractId=3828, patchId=41)
+
+        cls.dataRefsDict = {
+            visit_id: construct_geometry(visit_id) for visit_id in (204706, 204708)
+        }
+
+        cls.common = CommonComponents(
+            units=CoaddUnits.nJy,
+            wcs=cls.skyInfo.patchInfo.wcs,
+            band="fakeFilter",
+            identifiers=PatchIdentifiers(
+                skymap="cells", tract=3828, patch=41, band="fakeFilter"
+            ),
+        )
+
+    def setUp(self):
+        self.rng = np.random.RandomState(12345)
+
+        # Fill the input exposures.
+        # This needs to be redone for each test, since the test may have
+        # modified the pixel values in-place.
+        for visit, exposureRefs in self.dataRefsDict.items():
+            for exposureRef in exposureRefs:
+                fill_exposure(exposureRef.get(), self.rng)
+
+        makeWarpConfig = MakeShearWarpConfig()
+        makeWarp = MakeShearWarpTask(config=makeWarpConfig)
+
+        self.warpDict, self.mfracWarpDict, self.noiseWarpDict = {}, {}, {}
+        for visit in self.dataRefsDict:
+            warp_result = makeWarp.run(
+                self.dataRefsDict[visit], self.skyInfo, visit_summary=None
+            )
+            self.warpDict[visit] = InMemoryDatasetHandle(
+                warp_result.warp, dataId=self.dataRefsDict[visit][0].dataId
+            )
+            self.mfracWarpDict[visit] = InMemoryDatasetHandle(
+                warp_result.mfrac_warp, dataId=self.dataRefsDict[visit][0].dataId
+            )
+
+            # The variance plane of noise warps get modified in-place.
+            # When run against an actual butler, this is not an issue since
+            # it is read in from disk/object storage everytime. We mimic this
+            # behavior by requiring that we get a new copy every time get() is
+            # called.
+            self.noiseWarpDict[visit] = InMemoryDatasetHandle(
+                warp_result.noise0_warp,
+                dataId=self.dataRefsDict[visit][0].dataId,
+                copy=True,
+            )
+
+    def tearDown(self):
+        for _, exposureRefs in self.dataRefsDict.items():
+            for exposureRef in exposureRefs:
+                exposureRef.get().mask.clearAllMaskPlanes()
+
+    @classmethod
+    def _constdfgdfgruct_geometry(cls, visit_id: int):
+        """Generate the necessary dataRefs to run the MakeWarpTask.
+
+        This is primarily setting up the geometry of the input exposures,
+        along with some metadata.
+        """
+
+        match visit_id:
+
+            case 204706:
+                crpixList = [
+                    lsst.geom.Point2D(1990.63, 2018.46),
+                    lsst.geom.Point2D(2186.46, 2044.82),
+                ]
+                crvalList = [
+                    lsst.geom.SpherePoint(
+                        57.14 * lsst.geom.degrees, -36.51 * lsst.geom.degrees
+                    ),
+                    lsst.geom.SpherePoint(
+                        57.39 * lsst.geom.degrees, -36.63 * lsst.geom.degrees
+                    ),
+                ]
+                cdMatrix = lsst.afw.geom.makeCdMatrix(
+                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                    orientation=122.9 * lsst.geom.degrees,
+                )
+                detectorNums = [158, 161]
+
+            case 204708:
+                crpixList = [
+                    lsst.geom.Point2D(2111.48, 1816.14),
+                    lsst.geom.Point2D(1971.88, 1899.54),
+                    lsst.geom.Point2D(1863.09, 1939.27),
+                ]
+                crvalList = [
+                    lsst.geom.SpherePoint(
+                        57.28 * lsst.geom.degrees, -36.66 * lsst.geom.degrees
+                    ),
+                    lsst.geom.SpherePoint(
+                        57.19 * lsst.geom.degrees, -36.35 * lsst.geom.degrees
+                    ),
+                    lsst.geom.SpherePoint(
+                        57.43 * lsst.geom.degrees, -36.48 * lsst.geom.degrees
+                    ),
+                ]
+                cdMatrix = lsst.afw.geom.makeCdMatrix(
+                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                    orientation=121.52 * lsst.geom.degrees,
+                )
+                detectorNums = [32, 36, 39]
+
+            case 174534:
+                crpixList = [
+                    lsst.geom.Point2D(1929.4499812439476, 2147.1179041443015),
+                    lsst.geom.Point2D(2012.9460541750886, 2073.7299107964782),
+                    lsst.geom.Point2D(2259.5002281485358, 2105.9109483821226),
+                ]
+                crvalList = [
+                    lsst.geom.SpherePoint(
+                        55.94990987622795 * lsst.geom.degrees,
+                        -36.18810977436167 * lsst.geom.degrees,
+                    ),
+                    lsst.geom.SpherePoint(
+                        56.02684930702103 * lsst.geom.degrees,
+                        -35.96612774405456 * lsst.geom.degrees,
+                    ),
+                    lsst.geom.SpherePoint(
+                        55.733500259251784 * lsst.geom.degrees,
+                        -35.89282833381862 * lsst.geom.degrees,
+                    ),
+                ]
+                cdMatrix = lsst.afw.geom.makeCdMatrix(
+                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                    orientation=16.69 * lsst.geom.degrees,
+                )
+                detectorNums = [12, 15, 16]
+
+            case 397330:
+
+                crpixList = [
+                    lsst.geom.Point2D(2038.0123728146252, 1886.2009723798765),
+                    lsst.geom.Point2D(2165.4630755512139, 1991.9349231803017),
+                ]
+                crvalList = [
+                    lsst.geom.SpherePoint(
+                        56.05982507585136 * lsst.geom.degrees,
+                        -36.04171236047266 * lsst.geom.degrees,
+                    ),
+                    lsst.geom.SpherePoint(
+                        56.01232760335289 * lsst.geom.degrees,
+                        -35.80314141320685 * lsst.geom.degrees,
+                    ),
+                ]
+                cdMatrix = lsst.afw.geom.makeCdMatrix(
+                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                    orientation=352.56 * lsst.geom.degrees,
+                )
+
+                detectorNums = [78, 117]
+
+            case 1248:
+                crpixList = [
+                    lsst.geom.Point2D(2047.84, 1909.10),
+                    lsst.geom.Point2D(2110.05, 1982.96),
+                    lsst.geom.Point2D(2104.22, 1780.364),
+                ]
+                crvalList = [
+                    lsst.geom.SpherePoint(
+                        56.16 * lsst.geom.degrees, -36.84 * lsst.geom.degrees
+                    ),
+                    lsst.geom.SpherePoint(
+                        56.33 * lsst.geom.degrees, -36.64 * lsst.geom.degrees
+                    ),
+                    lsst.geom.SpherePoint(
+                        56.40 * lsst.geom.degrees, -36.96 * lsst.geom.degrees
+                    ),
+                ]
+                cdMatrix = lsst.afw.geom.makeCdMatrix(
+                    scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                    orientation=123.5 * lsst.geom.degrees,
+                )
+
+                detectorNums = [107, 114, 146]
+
+            case _:
+                raise ValueError(
+                    f"{visit_id} is not supported. It must be one of "
+                    "[1248, 204706, 397330]"
+                )
+
+        dataRefs = []
+
+        for detId, detectorNum in enumerate(detectorNums):
+            wcs = lsst.afw.geom.makeSkyWcs(crpixList[detId], crvalList[detId], cdMatrix)
+            exposure = afw_image.ExposureF(cls.nx, cls.ny)
+
+            # Set the PhotoCalib, Wcs and detector objects of this exposure.
+            exposure.setPhotoCalib(cls.photoCalib)
+            exposure.setPsf(GaussianPsf(25, 25, 2.5))
+            exposure.setFilter(
+                afw_image.FilterLabel(physical="fakeFilter", band="fake")
+            )
+            exposure.setWcs(wcs)
+
+            detectorName = f"detector {detectorNum}"
+            detector = lsst.afw.cameraGeom.testUtils.DetectorWrapper(
+                name=detectorName,
+                id=detectorNum,
+            ).detector
+            exposure.setDetector(detector)
+
+            dataId_dict = {
+                "detector_id": detectorNum,
+                "visit_id": visit_id,
+                "band": "fake",
+            }
+            dataId = generate_data_id(**dataId_dict)
+            dataRef = InMemoryDatasetHandle(exposure, dataId=dataId)
+
+            dataRefs.append(dataRef)
+
+        return dataRefs
+
+    def checkSortOrder(self, inputs: Iterable[ObservationIdentifiers]) -> None:
+        """Check that the inputs are sorted.
+
+        The inputs must be sorted first by visit, and within the same visit,
+        by detector.
+
+        Parameters
+        ----------
+        inputs : `Iterable` [`ObservationIdentifiers`]
+            The inputs to be checked.
+        """
+        visit, detector = -np.inf, -np.inf  # Previous visit, detector IDs.
+        for _, obsId in enumerate(inputs):
+            with self.subTest(input_number=obsId):
+                self.assertGreaterEqual(obsId.visit, visit)
+            if visit == obsId.visit:
+                with self.subTest(detector_number=obsId.detector):
+                    self.assertGreaterEqual(obsId.detector, detector)
+
+            visit, detector = obsId.visit, obsId.detector
+
+    def checkPsfImage(self, psf_image):
+        """Check that the PSF image is a valid image."""
+
+        psf_dimensions = psf_image.getDimensions()
+        self.assertEqual(psf_dimensions.x, self.task.config.psf_dimensions)
+        self.assertEqual(psf_dimensions.y, self.task.config.psf_dimensions)
+
+        array = psf_image.array
+        self.assertGreaterEqual(array.min(), 0)  # Pixel values must be non-negative.
+        self.assertLessEqual(array.sum(), 1)
+        self.assertGreaterEqual(array.sum(), 0.995)  # It does not sum to 1 exactly.
+
+    def checkRun(self, result):
+        """Check that the task runs successfully."""
+
+        max_visit_count = len(self.warpDict)
+
+        # Check that we produced a MultipleCellCoadd instance.
+        self.assertTrue(isinstance(result.multiple_cell_coadd, MultipleCellCoadd))
+        for cellId, single_cell_coadd in result.multiple_cell_coadd.cells.items():
+            # Use subTest context manager so this gets run for each cell
+            # and collect all failures.
+            with self.subTest(x=cellId.x, y=cellId.y):
+                # Check that the visit_count method returns a number less than
+                # or equal to the total number of input exposures available.
+                self.assertLessEqual(single_cell_coadd.visit_count, max_visit_count)
+
+                # Check that the inputs are sorted.
+                self.checkSortOrder(single_cell_coadd.inputs)
+
+                # Check that the PSF image
+                self.checkPsfImage(single_cell_coadd.psf_image)
+
+    def testCoaddSmoke(self):
+        config = MockAssembleShearCoaddSlowTask.ConfigClass()
+        self.task = MockAssembleShearCoaddSlowTask(config=config)
+        # task is an attribute so the check methods can access its config.
+
+        result = self.task.run(
+            input_warps=self.warpDict.values(),
+            noise_warps=self.noiseWarpDict.values(),
+            mfrac_warps=self.mfracWarpDict.values(),
+            skyInfo=self.skyInfo,
+            common=self.common,
+        )
+
+        self.checkRun(result)
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+class MatchMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    """Check for resource leaks."""
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()
+
+    # Run the test cases when invoked as a script.
+    tc = AssembleCoaddTestCase()
+    tc.setUpClass()
+    tc.setUp()
+    tc.testCoaddSmoke()

--- a/descwl_coadd_task/utils_for_tests.py
+++ b/descwl_coadd_task/utils_for_tests.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import lsst.afw.cameraGeom.testUtils
+import lsst.afw.image as afw_image
+import lsst.skymap as skyMap
+import lsst.utils.tests
+import numpy as np
+from lsst.afw.detection import GaussianPsf
+from lsst.daf.butler import DataCoordinate, DimensionUniverse
+from lsst.pipe.base import InMemoryDatasetHandle
+
+__all__ = [
+    "build_skyMap",
+    "construct_geometry",
+    "generate_photoCalib",
+    "generate_data_id",
+    "fill_exposure",
+]
+
+
+PIXEL_SCALE = 0.2
+"""Pixel scale in arcseconds"""
+
+
+def build_skyMap():
+    """Build a simple skyMap."""
+    simpleMapConfig = skyMap.ringsSkyMap.RingsSkyMapConfig()
+    simpleMapConfig.numRings = 120
+    simpleMapConfig.pixelScale = 0.2
+    simpleMapConfig.projection = "TAN"
+    simpleMapConfig.tractBuilder = "cells"
+    simpleMapConfig.tractOverlap = 1 / 60
+
+    return skyMap.ringsSkyMap.RingsSkyMap(simpleMapConfig)
+
+
+def generate_photoCalib(meanCalibration=1e-4, calibrationErr=1e-5):
+    """Generate a PhotoCalib instance."""
+
+    return afw_image.PhotoCalib(
+        meanCalibration,
+        calibrationErr,
+    )
+
+
+def generate_data_id(
+    *,
+    tract: int = 3828,
+    patch: int = 41,
+    band: str = "fake",
+    detector_id: int = 9,
+    visit_id: int = 1234,
+    detector_max: int = 189,
+    visit_max: int = 1000000,
+) -> DataCoordinate:
+    """Generate a DataCoordinate instance to use as data_id.
+
+    Parameters
+    ----------
+    tract : `int`, optional
+        Tract ID for the data_id
+    patch : `int`, optional
+        Patch ID for the data_id
+    band : `str`, optional
+        Band for the data_id
+    detector_id : `int`, optional
+        Detector ID for the data_id
+    visit_id : `int`, optional
+        Visit ID for the data_id
+    detector_max : `int`, optional
+        Maximum detector ID for the data_id
+    visit_max : `int`, optional
+        Maximum visit ID for the data_id
+
+    Returns
+    -------
+    data_id : `lsst.daf.butler.DataCoordinate`
+        An expanded data_id instance.
+    """
+    universe = DimensionUniverse()
+
+    instrument = universe["instrument"]
+    instrument_record = instrument.RecordClass(
+        name="DummyCam",
+        class_name="lsst.obs.base.instrument_tests.DummyCam",
+        detector_max=detector_max,
+        visit_max=visit_max,
+    )
+
+    skymap = universe["skymap"]
+    skymap_record = skymap.RecordClass(name="test_skymap")
+
+    band_element = universe["band"]
+    band_record = band_element.RecordClass(name=band)
+
+    visit = universe["visit"]
+    visit_record = visit.RecordClass(id=visit_id, instrument="test")
+
+    detector = universe["detector"]
+    detector_record = detector.RecordClass(id=detector_id, instrument="test")
+
+    physical_filter = universe["physical_filter"]
+    physical_filter_record = physical_filter.RecordClass(
+        name=band, instrument="test", band=band
+    )
+
+    patch_element = universe["patch"]
+    patch_record = patch_element.RecordClass(
+        skymap="test_skymap",
+        tract=tract,
+        patch=patch,
+    )
+
+    if "day_obs" in universe:
+        day_obs_element = universe["day_obs"]
+        day_obs_record = day_obs_element.RecordClass(id=20240201, instrument="test")
+    else:
+        day_obs_record = None
+
+    # A dictionary with all the relevant records.
+    record = {
+        "instrument": instrument_record,
+        "visit": visit_record,
+        "detector": detector_record,
+        "patch": patch_record,
+        "tract": tract,
+        "band": band_record.name,
+        "skymap": skymap_record.name,
+        "physical_filter": physical_filter_record,
+    }
+
+    if day_obs_record:
+        record["day_obs"] = day_obs_record
+
+    # A dictionary with all the relevant recordIds.
+    record_id = record.copy()
+    for key in ("visit", "detector"):
+        record_id[key] = record_id[key].id
+
+    data_id = DataCoordinate.standardize(record_id, universe=universe)
+    return data_id.expanded(record)
+
+
+def fill_exposure(exposure, rng, mask_pixel=False, mask_bitname="SAT"):
+    """Fill an exposure with random data.
+
+    Parameters
+    ----------
+    mask_pixel : `bool`, optional
+        If True, a pixel will be masked in the exposure.
+    mask_bitname : `str`, optional
+        Name of the mask bit to set.
+
+    Returns
+    -------
+    exposure : `lsst.afw.image.ExposureF`
+        The modified exposure.
+
+    Notes
+    -----
+    The input ``exposure`` is modified in-place.
+    """
+    exposure.maskedImage.image.array = (
+        rng.uniform(size=exposure.image.array.shape).astype(np.float32) * 1000
+    )
+    exposure.maskedImage.variance.array = rng.uniform(
+        low=0.98,
+        high=1.0,
+        size=exposure.image.array.shape,
+    ).astype(np.float32)
+
+    if mask_pixel:
+        exposure.maskedImage.mask[5, 5] = afw_image.Mask.getPlaneBitMask(mask_bitname)
+
+    return exposure
+
+
+def construct_geometry(visit_id: int, nx: int = 4072, ny: int = 4000):
+    """Generate the necessary dataRefs to run the MakeWarpTask.
+
+    This is primarily setting up the geometry of the input exposures,
+    along with some metadata.
+    """
+
+    match visit_id:
+
+        case 204706:
+            crpixList = [
+                lsst.geom.Point2D(1990.63, 2018.46),
+                lsst.geom.Point2D(2186.46, 2044.82),
+            ]
+            crvalList = [
+                lsst.geom.SpherePoint(
+                    57.14 * lsst.geom.degrees, -36.51 * lsst.geom.degrees
+                ),
+                lsst.geom.SpherePoint(
+                    57.39 * lsst.geom.degrees, -36.63 * lsst.geom.degrees
+                ),
+            ]
+            cdMatrix = lsst.afw.geom.makeCdMatrix(
+                scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                orientation=122.9 * lsst.geom.degrees,
+            )
+            detectorNums = [158, 161]
+
+        case 204708:
+            crpixList = [
+                lsst.geom.Point2D(2111.48, 1816.14),
+                lsst.geom.Point2D(1971.88, 1899.54),
+                lsst.geom.Point2D(1863.09, 1939.27),
+            ]
+            crvalList = [
+                lsst.geom.SpherePoint(
+                    57.28 * lsst.geom.degrees, -36.66 * lsst.geom.degrees
+                ),
+                lsst.geom.SpherePoint(
+                    57.19 * lsst.geom.degrees, -36.35 * lsst.geom.degrees
+                ),
+                lsst.geom.SpherePoint(
+                    57.43 * lsst.geom.degrees, -36.48 * lsst.geom.degrees
+                ),
+            ]
+            cdMatrix = lsst.afw.geom.makeCdMatrix(
+                scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                orientation=121.52 * lsst.geom.degrees,
+            )
+            detectorNums = [32, 36, 39]
+
+        case 174534:
+            crpixList = [
+                lsst.geom.Point2D(1929.4499812439476, 2147.1179041443015),
+                lsst.geom.Point2D(2012.9460541750886, 2073.7299107964782),
+                lsst.geom.Point2D(2259.5002281485358, 2105.9109483821226),
+            ]
+            crvalList = [
+                lsst.geom.SpherePoint(
+                    55.94990987622795 * lsst.geom.degrees,
+                    -36.18810977436167 * lsst.geom.degrees,
+                ),
+                lsst.geom.SpherePoint(
+                    56.02684930702103 * lsst.geom.degrees,
+                    -35.96612774405456 * lsst.geom.degrees,
+                ),
+                lsst.geom.SpherePoint(
+                    55.733500259251784 * lsst.geom.degrees,
+                    -35.89282833381862 * lsst.geom.degrees,
+                ),
+            ]
+            cdMatrix = lsst.afw.geom.makeCdMatrix(
+                scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                orientation=16.69 * lsst.geom.degrees,
+            )
+            detectorNums = [12, 15, 16]
+
+        case 397330:
+
+            crpixList = [
+                lsst.geom.Point2D(2038.0123728146252, 1886.2009723798765),
+                lsst.geom.Point2D(2165.4630755512139, 1991.9349231803017),
+            ]
+            crvalList = [
+                lsst.geom.SpherePoint(
+                    56.05982507585136 * lsst.geom.degrees,
+                    -36.04171236047266 * lsst.geom.degrees,
+                ),
+                lsst.geom.SpherePoint(
+                    56.01232760335289 * lsst.geom.degrees,
+                    -35.80314141320685 * lsst.geom.degrees,
+                ),
+            ]
+            cdMatrix = lsst.afw.geom.makeCdMatrix(
+                scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                orientation=352.56 * lsst.geom.degrees,
+            )
+
+            detectorNums = [78, 117]
+
+        case 1248:
+            crpixList = [
+                lsst.geom.Point2D(2047.84, 1909.10),
+                lsst.geom.Point2D(2110.05, 1982.96),
+                lsst.geom.Point2D(2104.22, 1780.364),
+            ]
+            crvalList = [
+                lsst.geom.SpherePoint(
+                    56.16 * lsst.geom.degrees, -36.84 * lsst.geom.degrees
+                ),
+                lsst.geom.SpherePoint(
+                    56.33 * lsst.geom.degrees, -36.64 * lsst.geom.degrees
+                ),
+                lsst.geom.SpherePoint(
+                    56.40 * lsst.geom.degrees, -36.96 * lsst.geom.degrees
+                ),
+            ]
+            cdMatrix = lsst.afw.geom.makeCdMatrix(
+                scale=PIXEL_SCALE * lsst.geom.arcseconds,
+                orientation=123.5 * lsst.geom.degrees,
+            )
+            detectorNums = [107, 114, 146]
+
+        case _:
+            raise ValueError(
+                f"{visit_id} is not supported. It must be one of [1248, 204706, 397330]"
+            )
+
+    dataRefs = []
+
+    for detId, detectorNum in enumerate(detectorNums):
+        wcs = lsst.afw.geom.makeSkyWcs(crpixList[detId], crvalList[detId], cdMatrix)
+        exposure = afw_image.ExposureF(nx, ny)
+
+        # Set the PhotoCalib, Wcs and detector objects of this exposure.
+        exposure.setPhotoCalib(generate_photoCalib())
+        exposure.setPsf(GaussianPsf(25, 25, 2.5))
+        exposure.setFilter(afw_image.FilterLabel(physical="fakeFilter", band="fake"))
+        exposure.setWcs(wcs)
+
+        detectorName = f"detector {detectorNum}"
+        detector = lsst.afw.cameraGeom.testUtils.DetectorWrapper(
+            name=detectorName,
+            id=detectorNum,
+        ).detector
+        exposure.setDetector(detector)
+
+        dataId_dict = {"detector_id": detectorNum, "visit_id": visit_id, "band": "fake"}
+        dataId = generate_data_id(**dataId_dict)
+        dataRef = InMemoryDatasetHandle(exposure, dataId=dataId)
+
+        dataRefs.append(dataRef)
+
+    return dataRefs


### PR DESCRIPTION
This PR sets up the framework to run warping _and_ coaddition tasks and demonstrates some of the interfaces to look at the single cell images and PSFs. Right now, the exposures are just noise themselves. My intention here is to set up the geometry of the input exposures, and override `fill_exposures` later to have sky scenes instead of pure noise. I've also included some minor bug fixes that I found as I wrote the tests.